### PR TITLE
qdsp6: Allow audio_rx_path_id to be zero, fixes Bluetooth

### DIFF
--- a/arch/arm/mach-msm/qdsp6/q6audio.c
+++ b/arch/arm/mach-msm/qdsp6/q6audio.c
@@ -1450,16 +1450,14 @@ done:
 
 static void adie_rx_path_enable(uint32_t acdb_id)
 {
-        if (audio_rx_path_id) {
-                adie_enable();
-                adie_set_path(adie, audio_rx_path_id, ADIE_PATH_RX);
-                adie_set_path_freq_plan(adie, ADIE_PATH_RX, 48000);
+	adie_enable();
+	adie_set_path(adie, audio_rx_path_id, ADIE_PATH_RX);
+	adie_set_path_freq_plan(adie, ADIE_PATH_RX, 48000);
 
-                adie_proceed_to_stage(adie, ADIE_PATH_RX,
-                                ADIE_STAGE_DIGITAL_READY);
-                adie_proceed_to_stage(adie, ADIE_PATH_RX,
-                                ADIE_STAGE_DIGITAL_ANALOG_READY);
-        }
+	adie_proceed_to_stage(adie, ADIE_PATH_RX,
+			ADIE_STAGE_DIGITAL_READY);
+	adie_proceed_to_stage(adie, ADIE_PATH_RX,
+			ADIE_STAGE_DIGITAL_ANALOG_READY);
 }
 
 static void q6_rx_path_enable(int reconf, uint32_t acdb_id)


### PR DESCRIPTION
In the refactoring done by commit 8913be80, the new adie_rx_path_enable
added a check for audio_rx_path_id!=0 that didn't exist before.  It
becomes 0 for example when using Bluetooth voice dial.  I found that
CAF's kernels also do this, but they make the same check around every
adie_proceed_to_stage() call throughout.  Since we only have it in one
place, the audio can get into a confused state and stop working.

This patch removes the audio_rx_path_id check, so the logic more closely
matches what we had before, and now BT is fine again.

Change-Id: I9a4f437597b1a5f509517b88f8fd9369e6f7ad7d
